### PR TITLE
Update Go versions in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-    - 1.7.x
+    - 1.11.x
     - tip
 
 install:


### PR DESCRIPTION
Align Go versions used in Travis with main containerd project

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>