### PR TITLE
Use defined error var

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,30 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fifo
+
+import (
+	"errors"
+)
+
+var (
+  ErrClosed       = errors.New("fifo closed")
+  ErrCtrlClosed   = errors.New("control of closed fifo")
+  ErrRdFrmWRONLY  = errors.New("reading from write-only fifo")
+  ErrReadClosed   = errors.New("reading from a closed fifo")
+  ErrWrToRDONLY   = errors.New("writing to read-only fifo")
+  ErrWriteClosed  = errors.New("writing to a closed fifo")
+)

--- a/fifo.go
+++ b/fifo.go
@@ -147,7 +147,7 @@ func OpenFifo(ctx context.Context, fn string, flag int, perm os.FileMode) (io.Re
 // Read from a fifo to a byte array.
 func (f *fifo) Read(b []byte) (int, error) {
 	if f.flag&syscall.O_WRONLY > 0 {
-		return 0, errors.New("reading from write-only fifo")
+		return 0, ErrRdFrmWRONLY
 	}
 	select {
 	case <-f.opened:
@@ -158,14 +158,14 @@ func (f *fifo) Read(b []byte) (int, error) {
 	case <-f.opened:
 		return f.file.Read(b)
 	case <-f.closed:
-		return 0, errors.New("reading from a closed fifo")
+		return 0, ErrReadClosed
 	}
 }
 
 // Write from byte array to a fifo.
 func (f *fifo) Write(b []byte) (int, error) {
 	if f.flag&(syscall.O_WRONLY|syscall.O_RDWR) == 0 {
-		return 0, errors.New("writing to read-only fifo")
+		return 0, ErrWrToRDONLY
 	}
 	select {
 	case <-f.opened:
@@ -176,7 +176,7 @@ func (f *fifo) Write(b []byte) (int, error) {
 	case <-f.opened:
 		return f.file.Write(b)
 	case <-f.closed:
-		return 0, errors.New("writing to a closed fifo")
+		return 0, ErrWriteClosed
 	}
 }
 

--- a/raw.go
+++ b/raw.go
@@ -20,8 +20,6 @@ package fifo
 
 import (
 	"syscall"
-
-	"github.com/pkg/errors"
 )
 
 // SyscallConn provides raw access to the fifo's underlying filedescrptor.
@@ -30,13 +28,13 @@ func (f *fifo) SyscallConn() (syscall.RawConn, error) {
 	// deterministic check for closed
 	select {
 	case <-f.closed:
-		return nil, errors.New("fifo closed")
+		return nil, ErrClosed
 	default:
 	}
 
 	select {
 	case <-f.closed:
-		return nil, errors.New("fifo closed")
+		return nil, ErrClosed
 	case <-f.opened:
 		return f.file.SyscallConn()
 	default:
@@ -68,7 +66,7 @@ type rawConn struct {
 func (r *rawConn) Control(f func(fd uintptr)) error {
 	select {
 	case <-r.f.closed:
-		return errors.New("control of closed fifo")
+		return ErrCtrlClosed
 	case <-r.ready:
 	}
 
@@ -81,12 +79,12 @@ func (r *rawConn) Control(f func(fd uintptr)) error {
 
 func (r *rawConn) Read(f func(fd uintptr) (done bool)) error {
 	if r.f.flag&syscall.O_WRONLY > 0 {
-		return errors.New("reading from write-only fifo")
+		return ErrRdFrmWRONLY
 	}
 
 	select {
 	case <-r.f.closed:
-		return errors.New("reading of a closed fifo")
+		return ErrReadClosed
 	case <-r.ready:
 	}
 
@@ -99,12 +97,12 @@ func (r *rawConn) Read(f func(fd uintptr) (done bool)) error {
 
 func (r *rawConn) Write(f func(fd uintptr) (done bool)) error {
 	if r.f.flag&(syscall.O_WRONLY|syscall.O_RDWR) == 0 {
-		return errors.New("writing to read-only fifo")
+		return ErrWrToRDONLY
 	}
 
 	select {
 	case <-r.f.closed:
-		return errors.New("writing to a closed fifo")
+		return ErrWriteClosed
 	case <-r.ready:
 	}
 


### PR DESCRIPTION
Return a defined error var so that we can check the error type later.

relate to: https://github.com/containerd/containerd/pull/3536
/cc @fuweid 

Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>