### PR TITLE
readme: update badges to show GHA status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Go
+name: CI
 
 on:
   push:

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,9 @@
 ### fifo
 
-[![Build Status](https://travis-ci.org/containerd/fifo.svg?branch=master)](https://travis-ci.org/containerd/fifo)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/containerd/fifo)](https://pkg.go.dev/github.com/containerd/fifo)
+[![Build Status](https://github.com/containerd/fifo/workflows/CI/badge.svg)](https://github.com/containerd/fifo/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/containerd/fifo/branch/master/graph/badge.svg)](https://codecov.io/gh/containerd/fifo)
+[![Go Report Card](https://goreportcard.com/badge/github.com/containerd/fifo)](https://goreportcard.com/report/github.com/containerd/fifo)
 
 Go package for handling fifos in a sane way.
 


### PR DESCRIPTION
This was overlooked when switching to GHA. Also adds badges for go.pkg.dev and Go Report Card.
