### PR TITLE
exclude OpenFifoDup2() on Windows

### DIFF
--- a/fifo.go
+++ b/fifo.go
@@ -25,7 +25,6 @@ import (
 	"syscall"
 
 	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 )
 
 type fifo struct {
@@ -44,17 +43,7 @@ var leakCheckWg *sync.WaitGroup
 
 // OpenFifoDup2 is same as OpenFifo, but additionally creates a copy of the FIFO file descriptor with dup2 syscall.
 func OpenFifoDup2(ctx context.Context, fn string, flag int, perm os.FileMode, fd int) (io.ReadWriteCloser, error) {
-	f, err := openFifo(ctx, fn, flag, perm)
-	if err != nil {
-		return nil, errors.Wrap(err, "fifo error")
-	}
-
-	if err := unix.Dup2(int(f.file.Fd()), fd); err != nil {
-		_ = f.Close()
-		return nil, errors.Wrap(err, "dup2 error")
-	}
-
-	return f, nil
+	return openFifoDup2(ctx, fn, flag, perm, fd)
 }
 
 // OpenFifo opens a fifo. Returns io.ReadWriteCloser.

--- a/fifo_unix.go
+++ b/fifo_unix.go
@@ -1,0 +1,43 @@
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fifo
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// openFifoDup2 is same as OpenFifo, but additionally creates a copy of the FIFO file descriptor with dup2 syscall.
+func openFifoDup2(ctx context.Context, fn string, flag int, perm os.FileMode, fd int) (io.ReadWriteCloser, error) {
+	f, err := openFifo(ctx, fn, flag, perm)
+	if err != nil {
+		return nil, errors.Wrap(err, "fifo error")
+	}
+
+	if err := unix.Dup2(int(f.file.Fd()), fd); err != nil {
+		_ = f.Close()
+		return nil, errors.Wrap(err, "dup2 error")
+	}
+
+	return f, nil
+}

--- a/fifo_windows.go
+++ b/fifo_windows.go
@@ -1,0 +1,30 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fifo
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+// openFifoDup2 is not supported on Windows
+func openFifoDup2(ctx context.Context, fn string, flag int, perm os.FileMode, fd int) (io.ReadWriteCloser, error) {
+	return nil, errors.New("not supported")
+}


### PR DESCRIPTION
Commit 9c214ed89d26d752014024b90fbb82b14f70ea18 (https://github.com/containerd/fifo/pull/28) updated this function, and replaced `syscall.Dup2()` for `golang.org/x/sys/unix.Dup2()`, which is not available on Windows.

This patch splits the API from the implementation, and moves the unix implementation to a "unix" file; as stub is added for Windows.
