### PR TITLE
Remove references to io/ioutil package

### DIFF
--- a/fifo_linux_test.go
+++ b/fifo_linux_test.go
@@ -21,7 +21,6 @@ package fifo
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -33,7 +32,7 @@ import (
 )
 
 func TestFifoCloseAfterRm(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "fifos")
+	tmpdir, err := os.MkdirTemp("", "fifos")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 

--- a/fifo_nolinux_test.go
+++ b/fifo_nolinux_test.go
@@ -21,7 +21,6 @@ package fifo
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -32,7 +31,7 @@ import (
 )
 
 func TestFifoCloseAfterRm(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "fifos")
+	tmpdir, err := os.MkdirTemp("", "fifos")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 

--- a/fifo_test.go
+++ b/fifo_test.go
@@ -22,7 +22,6 @@ package fifo
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -34,7 +33,7 @@ import (
 )
 
 func TestFifoCancel(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "fifos")
+	tmpdir, err := os.MkdirTemp("", "fifos")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -68,7 +67,7 @@ func TestFifoCancel(t *testing.T) {
 }
 
 func TestFifoReadWrite(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "fifos")
+	tmpdir, err := os.MkdirTemp("", "fifos")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -146,7 +145,7 @@ func TestFifoReadWrite(t *testing.T) {
 }
 
 func TestFifoCancelOneSide(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "fifos")
+	tmpdir, err := os.MkdirTemp("", "fifos")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -189,7 +188,7 @@ func TestFifoCancelOneSide(t *testing.T) {
 }
 
 func TestFifoBlocking(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "fifos")
+	tmpdir, err := os.MkdirTemp("", "fifos")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -256,7 +255,7 @@ func TestFifoBlocking(t *testing.T) {
 }
 
 func TestFifoORDWR(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "fifos")
+	tmpdir, err := os.MkdirTemp("", "fifos")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -332,7 +331,7 @@ func TestFifoORDWR(t *testing.T) {
 }
 
 func TestFifoCloseError(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "fifos")
+	tmpdir, err := os.MkdirTemp("", "fifos")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -357,7 +356,7 @@ func TestFifoCloseError(t *testing.T) {
 }
 
 func TestFifoCloseWhileReading(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "fifos")
+	tmpdir, err := os.MkdirTemp("", "fifos")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -397,7 +396,7 @@ func TestFifoCloseWhileReading(t *testing.T) {
 }
 
 func TestFifoCloseWhileReadingAndWriting(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "fifos")
+	tmpdir, err := os.MkdirTemp("", "fifos")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -447,7 +446,7 @@ func TestFifoCloseWhileReadingAndWriting(t *testing.T) {
 }
 
 func TestFifoWrongRdWrError(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "fifos")
+	tmpdir, err := os.MkdirTemp("", "fifos")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 

--- a/raw_test.go
+++ b/raw_test.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -35,7 +34,7 @@ import (
 )
 
 func TestRawReadWrite(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "fifos")
+	tmpdir, err := os.MkdirTemp("", "fifos")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -63,7 +62,7 @@ func TestRawReadWrite(t *testing.T) {
 }
 
 func TestRawWriteUserRead(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "fifos")
+	tmpdir, err := os.MkdirTemp("", "fifos")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -90,7 +89,7 @@ func TestRawWriteUserRead(t *testing.T) {
 }
 
 func TestUserWriteRawRead(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "fifos")
+	tmpdir, err := os.MkdirTemp("", "fifos")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -118,7 +117,7 @@ func TestUserWriteRawRead(t *testing.T) {
 }
 
 func TestRawCloseError(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "fifos")
+	tmpdir, err := os.MkdirTemp("", "fifos")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -176,7 +175,7 @@ func TestRawCloseError(t *testing.T) {
 }
 
 func TestRawWrongRdWrError(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "fifos")
+	tmpdir, err := os.MkdirTemp("", "fifos")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 


### PR DESCRIPTION
io/ioutil has been marked deprecated in Go 1.16.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>