### PR TITLE
Update GitHub actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,18 @@ jobs:
 
   checks:
     name: Project Checks
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         path: src/github.com/containerd/fifo
         fetch-depth: 25
     - uses: actions/setup-go@v3
       with:
         go-version: 1.18.x
-    - uses: containerd/project-checks@v1.0.2
+    - uses: containerd/project-checks@v1.1.0
       with:
         working-directory: src/github.com/containerd/fifo
 
@@ -33,10 +33,10 @@ jobs:
     strategy:
       matrix:
         go-version: [1.18.x]
-        os: [ubuntu-18.04, macos-10.15, windows-2019]
+        os: [ubuntu-22.04, macos-12, windows-2022]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/fifo
 
@@ -48,20 +48,20 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.47.1
+          version: v1.50.1
           working-directory: src/github.com/containerd/fifo
 
   tests:
     name: Tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/fifo
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,5 @@
 linters:
   enable:
-    - structcheck
-    - varcheck
     - staticcheck
     - unconvert
     - gofmt

--- a/fifo.go
+++ b/fifo.go
@@ -63,11 +63,11 @@ func OpenFifoDup2(ctx context.Context, fn string, flag int, perm os.FileMode, fd
 // OpenFifo opens a fifo. Returns io.ReadWriteCloser.
 // Context can be used to cancel this function until open(2) has not returned.
 // Accepted flags:
-// - syscall.O_CREAT - create new fifo if one doesn't exist
-// - syscall.O_RDONLY - open fifo only from reader side
-// - syscall.O_WRONLY - open fifo only from writer side
-// - syscall.O_RDWR - open fifo from both sides, never block on syscall level
-// - syscall.O_NONBLOCK - return io.ReadWriteCloser even if other side of the
+//   - syscall.O_CREAT - create new fifo if one doesn't exist
+//   - syscall.O_RDONLY - open fifo only from reader side
+//   - syscall.O_WRONLY - open fifo only from writer side
+//   - syscall.O_RDWR - open fifo from both sides, never block on syscall level
+//   - syscall.O_NONBLOCK - return io.ReadWriteCloser even if other side of the
 //     fifo isn't open. read/write will be connected after the actual fifo is
 //     open or after fifo is closed.
 func OpenFifo(ctx context.Context, fn string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {


### PR DESCRIPTION
Update actions runner OS image from Ubuntu 18.04 to Ubuntu 22.04, MacOS 10.15 to MacOS 12, and Windows 2019 to Windows 2022. Update actions/checkout and actions/setup-go from v2 to v3. Update containerd/project-checks from v1.0.2 to v1.1.0. Update golangci/golangci-lint from v1.47.1 to v1.50.1. Removed deprecated linters. Ran go fmt.

Related issue: https://github.com/containerd/project/issues/95

Signed-off-by: Austin Vazquez <macedonv@amazon.com>