### PR TITLE
Return nil when openFifo returns nil

### DIFF
--- a/fifo.go
+++ b/fifo.go
@@ -71,7 +71,13 @@ func OpenFifoDup2(ctx context.Context, fn string, flag int, perm os.FileMode, fd
 //     fifo isn't open. read/write will be connected after the actual fifo is
 //     open or after fifo is closed.
 func OpenFifo(ctx context.Context, fn string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {
-	return openFifo(ctx, fn, flag, perm)
+	fifo, err := openFifo(ctx, fn, flag, perm)
+	if fifo == nil {
+		// Do not return a non-nil ReadWriteCloser((*fifo)(nil)) value
+		// as that can confuse callers.
+		return nil, err
+	}
+	return fifo, err
 }
 
 func openFifo(ctx context.Context, fn string, flag int, perm os.FileMode) (*fifo, error) {

--- a/fifo_test.go
+++ b/fifo_test.go
@@ -42,7 +42,8 @@ func TestFifoCancel(t *testing.T) {
 		leakCheckWg = nil
 	}()
 
-	_, err = OpenFifo(context.Background(), filepath.Join(tmpdir, "f0"), syscall.O_RDONLY|syscall.O_NONBLOCK, 0600)
+	f, err := OpenFifo(context.Background(), filepath.Join(tmpdir, "f0"), syscall.O_RDONLY|syscall.O_NONBLOCK, 0600)
+	assert.Exactly(t, nil, f)
 	assert.NotNil(t, err)
 
 	assert.NoError(t, checkWgDone(leakCheckWg))
@@ -50,7 +51,7 @@ func TestFifoCancel(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
-	f, err := OpenFifo(ctx, filepath.Join(tmpdir, "f0"), syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0600)
+	f, err = OpenFifo(ctx, filepath.Join(tmpdir, "f0"), syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0600)
 	assert.NoError(t, err)
 
 	b := make([]byte, 32)
@@ -200,7 +201,8 @@ func TestFifoBlocking(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	_, err = OpenFifo(ctx, filepath.Join(tmpdir, "f0"), syscall.O_RDONLY|syscall.O_CREAT, 0600)
+	f, err := OpenFifo(ctx, filepath.Join(tmpdir, "f0"), syscall.O_RDONLY|syscall.O_CREAT, 0600)
+	assert.Exactly(t, nil, f)
 	assert.EqualError(t, err, "context deadline exceeded")
 
 	select {


### PR DESCRIPTION
The return statement in the `OpenFifo` wrapper function implicitly boxes the `*fifo` pointer into an `io.ReadWriteCloser` interface value, even when the value is `(*fifo)(nil)`. It is the same gotcha described in https://go.dev/doc/faq#nil_error and causes [the same sorts of confusing situations.](https://github.com/containerd/containerd/blob/b850554be20fd2a2423a930b748f4c7ee4207523/cio/io_unix.go#L114-L121) Modify the `OpenFifo` wrapper function to return a `nil` interface value when `openFifo` returns a `nil` pointer value.

* This appears to have been the only code path by which a `(*fifo)(nil)` value could escape the package, and therefore the root cause of https://github.com/docker/for-linux/issues/1186 for which #32 was added as a workaround.