### PR TITLE
Resolve golangci-lint-action package warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
-      - uses: golangci/golangci-lint-action@v3.2.0
+      - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.1
           working-directory: src/github.com/containerd/fifo


### PR DESCRIPTION
Use latest v3 version of golangci/golangci-lint-action to resolve `save-state` command usage warnings.

Latest mainline run: https://github.com/containerd/fifo/actions/runs/3339306551

Signed-off-by: Austin Vazquez <macedonv@amazon.com>