### PR TITLE
[Doc]Update links that changed default branch to main

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/containerd/fifo)](https://pkg.go.dev/github.com/containerd/fifo)
 [![Build Status](https://github.com/containerd/fifo/workflows/CI/badge.svg)](https://github.com/containerd/fifo/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/containerd/fifo/branch/master/graph/badge.svg)](https://codecov.io/gh/containerd/fifo)
+[![codecov](https://codecov.io/gh/containerd/fifo/branch/main/graph/badge.svg)](https://codecov.io/gh/containerd/fifo)
 [![Go Report Card](https://goreportcard.com/badge/github.com/containerd/fifo)](https://goreportcard.com/report/github.com/containerd/fifo)
 
 Go package for handling fifos in a sane way.
@@ -39,8 +39,8 @@ func (f *fifo) Close() error
 The fifo is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
 As a containerd sub-project, you will find the:
 
- * [Project governance](https://github.com/containerd/project/blob/master/GOVERNANCE.md),
- * [Maintainers](https://github.com/containerd/project/blob/master/MAINTAINERS),
- * and [Contributing guidelines](https://github.com/containerd/project/blob/master/CONTRIBUTING.md)
+ * [Project governance](https://github.com/containerd/project/blob/main/GOVERNANCE.md),
+ * [Maintainers](https://github.com/containerd/project/blob/main/MAINTAINERS),
+ * and [Contributing guidelines](https://github.com/containerd/project/blob/main/CONTRIBUTING.md)
 
 information in our [`containerd/project`](https://github.com/containerd/project) repository.


### PR DESCRIPTION
Since default branch of repo [github.com/containerd/project](https://github.com/containerd/project) changed to main, update the document links accordingly.
Those old links still work since github will redirect to the new default branch.

Signed-off-by: Tony Fang [nhfang@amazon.com](nhfang@amazon.com)